### PR TITLE
chore: GitHub ActionsのバージョンをSHAダイジェストにする

### DIFF
--- a/default.json
+++ b/default.json
@@ -22,6 +22,7 @@
   "labels": ["T: renovate"],
   "extends": [
     "config:recommended",
+    "helpers:pinGitHubActionDigests",
     "packages:eslint",
     "packages:react",
     "packages:vite"


### PR DESCRIPTION

related: pulsate-dev/pulsate#1206

## 概要
- 将来的にはOrg単位でSHA化を強制することになりそうなので、リポジトリ単位で設定するよりも全体で設定することにしてみました